### PR TITLE
Modify canvas update to round newWidth and newHeight to nearest integer

### DIFF
--- a/resources/js/scoutingPASS.js
+++ b/resources/js/scoutingPASS.js
@@ -1114,8 +1114,8 @@ function drawFields(name) {
     var imgWidth = img.width;
     var imgHeight = img.height;
     let scale_factor = Math.min(ctx.canvas.width / img.width, ctx.canvas.height / img.height);
-    let newWidth = img.width * scale_factor;
-    let newHeight = img.height * scale_factor;
+    let newWidth = Math.round(img.width * scale_factor);
+    let newHeight = Math.round(img.height * scale_factor);
     if (newWidth > 0) {
       ctx.canvas.width = newWidth
     }


### PR DESCRIPTION
[BUGFIX]

Issue: When clickable image (e.g. field image for auto/teleop shot locations) is updated after click, the canvas width and height are recalculated incorrectly, leading to canvas shrinking over many presses. 

Bug explanation: The canvas width and height are integers, but the calculated width and height are not (due to ratio between image size and canvas size being non-integer). Therefore, on every update the dimension that is slightly larger shrinks by 1 pixel due to the (fractional) new size being truncated down to integer. 

Fix: By rounding the new values to nearest integer, the canvas no longer shrinks on update, but the original intended behavior of recalculating the aspect ratio based on the image is left intact.